### PR TITLE
[Uptime] Update-paths-labeller-with-uptime

### DIFF
--- a/.github/paths-labeller.yml
+++ b/.github/paths-labeller.yml
@@ -8,3 +8,6 @@
   - "Feature:ExpressionLanguage":
     - "src/plugins/expressions/**/*.*"
     - "src/plugins/bfetch/**/*.*"
+  - "Team:uptime":
+    - "x-pack/plugins/uptime/**/*.*"
+    - "x-pack/legacy/plugins/uptime/**/*.*"


### PR DESCRIPTION
## Summary

Updated path labeler to add uptime labels so that bot can pick up changes and add 
Team:uptime label.