### PR TITLE
[RUM] General UI improvements

### DIFF
--- a/x-pack/plugins/apm/public/components/app/RumDashboard/ClientMetrics/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/RumDashboard/ClientMetrics/index.tsx
@@ -6,7 +6,7 @@
 // @flow
 import * as React from 'react';
 import styled from 'styled-components';
-import { EuiFlexGroup, EuiFlexItem, EuiStat } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiStat, EuiTitle } from '@elastic/eui';
 import { useFetcher } from '../../../../hooks/useFetcher';
 import { useUrlParams } from '../../../../hooks/useUrlParams';
 import { BackEndLabel, FrontEndLabel, PageViewsLabel } from '../translations';
@@ -23,7 +23,7 @@ export const formatBigValue = (val?: number | null, fixed?: number): string => {
 };
 
 const ClFlexGroup = styled(EuiFlexGroup)`
-  flex-direction: column;
+  flex-direction: row;
   @media only screen and (max-width: 768px) {
     flex-direction: row;
     justify-content: space-between;
@@ -49,9 +49,11 @@ export const ClientMetrics = () => {
     [start, end, uiFilters]
   );
 
+  const STAT_STYLE = { width: '240px' };
+
   return (
     <ClFlexGroup responsive={false}>
-      <EuiFlexItem grow={false}>
+      <EuiFlexItem grow={false} style={STAT_STYLE}>
         <EuiStat
           titleSize="s"
           title={(data?.backEnd?.value?.toFixed(2) ?? '-') + ' sec'}
@@ -59,7 +61,7 @@ export const ClientMetrics = () => {
           isLoading={status !== 'success'}
         />
       </EuiFlexItem>
-      <EuiFlexItem grow={false}>
+      <EuiFlexItem grow={false} style={STAT_STYLE}>
         <EuiStat
           titleSize="s"
           title={(data?.frontEnd?.value?.toFixed(2) ?? '-') + ' sec'}
@@ -67,7 +69,7 @@ export const ClientMetrics = () => {
           isLoading={status !== 'success'}
         />
       </EuiFlexItem>
-      <EuiFlexItem grow={false}>
+      <EuiFlexItem grow={false} style={STAT_STYLE}>
         <EuiStat
           titleSize="s"
           title={formatBigValue(data?.pageViews?.value, 2) ?? '-'}

--- a/x-pack/plugins/apm/public/components/app/RumDashboard/PageLoadDistribution/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/RumDashboard/PageLoadDistribution/index.tsx
@@ -94,10 +94,9 @@ export const PageLoadDistribution = () => {
 
   return (
     <div>
-      <EuiSpacer size="m" />
       <EuiFlexGroup responsive={false}>
         <EuiFlexItem>
-          <EuiTitle size="s">
+          <EuiTitle size="xs">
             <h3>{PageLoadDistLabel}</h3>
           </EuiTitle>
         </EuiFlexItem>

--- a/x-pack/plugins/apm/public/components/app/RumDashboard/PageViewsTrend/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/RumDashboard/PageViewsTrend/index.tsx
@@ -72,8 +72,7 @@ export const PageViewsTrend = () => {
 
   return (
     <div>
-      <EuiSpacer size="l" />
-      <EuiTitle size="s">
+      <EuiTitle size="xs">
         <h3>{PageViewsLabel}</h3>
       </EuiTitle>
       <ChartWrapper loading={status !== 'success'} height="200px">

--- a/x-pack/plugins/apm/public/components/app/RumDashboard/RumDashboard.tsx
+++ b/x-pack/plugins/apm/public/components/app/RumDashboard/RumDashboard.tsx
@@ -4,7 +4,13 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { EuiFlexGroup, EuiFlexItem, EuiTitle, EuiSpacer } from '@elastic/eui';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiTitle,
+  EuiSpacer,
+  EuiPanel,
+} from '@elastic/eui';
 import React from 'react';
 import { ClientMetrics } from './ClientMetrics';
 import { PageViewsTrend } from './PageViewsTrend';
@@ -26,18 +32,32 @@ export function RumDashboard() {
   return (
     <>
       <EuiTitle>
-        <h1>{getWhatIsGoingOnLabel(environmentLabel)}</h1>
+        <h2>{getWhatIsGoingOnLabel(environmentLabel)}</h2>
       </EuiTitle>
-      <EuiSpacer size="l" />
-      <EuiFlexGroup justifyContent="spaceBetween">
-        <EuiFlexItem grow={1} data-cy={`client-metrics`}>
-          <ClientMetrics />
+      <EuiSpacer />
+      <EuiFlexGroup direction="column" gutterSize="s">
+        <EuiFlexItem>
+          <EuiPanel>
+            <EuiFlexGroup justifyContent="spaceBetween">
+              <EuiFlexItem grow={1} data-cy={`client-metrics`}>
+                <EuiTitle size="xs">
+                  <h3>Page load times</h3>
+                </EuiTitle>
+                <EuiSpacer size="s" />
+                <ClientMetrics />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiPanel>
         </EuiFlexItem>
-        <EuiFlexItem grow={3}>
-          <PageLoadDistribution />
-          <EuiSpacer size="xxl" />
-          <PageViewsTrend />
-          <EuiSpacer size="xxl" />
+        <EuiFlexItem>
+          <EuiPanel>
+            <EuiFlexGroup justifyContent="spaceBetween">
+              <EuiFlexItem grow={3}>
+                <PageLoadDistribution />
+                <PageViewsTrend />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiPanel>
         </EuiFlexItem>
       </EuiFlexGroup>
     </>

--- a/x-pack/plugins/apm/public/components/app/RumDashboard/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/RumDashboard/index.tsx
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { EuiPanel, EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 import React, { useMemo } from 'react';
 import { useTrackPageview } from '../../../../../observability/public';
 import { LocalUIFilters } from '../../shared/LocalUIFilters';
@@ -32,9 +32,7 @@ export function RumOverview() {
           <LocalUIFilters {...localUIFiltersConfig} showCount={true} />
         </EuiFlexItem>
         <EuiFlexItem grow={7}>
-          <EuiPanel>
-            <RumDashboard />
-          </EuiPanel>
+          <RumDashboard />
         </EuiFlexItem>
       </EuiFlexGroup>
     </>


### PR DESCRIPTION
## Summary

I would like to propose some layout improvements to make the view more consistent with the rest of APM.

![screencapture-localhost-5601-qvz-app-apm-2020-06-16-13_36_00](https://user-images.githubusercontent.com/4104278/84999452-731d7880-b151-11ea-84fd-03e9e1224204.png)

**Keep the APM title in the header** 
Not fixed here, but suggested to fix because the user is suddenly taken out of the context APM, yet they're still in APM. I find this confusing, and I imagine so will the user.

**Make two panels and let the KPIs sit on top of the other two charts.**
In my opinion, the side-by-side view doesn't help the charts. They get squeezed because of the filters on the left. We already have a similar pattern for the Time spent "KPI-style" and I would like to suggest to follow this for those EuiStat elements.

**Change the panel title sizes**
Again making it consistent with APM, decreasing the titles. And additionally, reducing the margins around the components making everything a bit tighter.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] ~~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
- [ ] ~~[Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
- [ ] ~~[Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios~~
- [ ] ~~This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~
- [ ] ~~This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)~~
- [ ] ~~This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~

### For maintainers

- [ ] ~~This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~~
