### PR TITLE
[SLO] Composite SLO: Phase 1 computation engine

### DIFF
--- a/x-pack/platform/packages/shared/kbn-slo-schema/src/rest_specs/routes/composite_slo/composite_slo_get.ts
+++ b/x-pack/platform/packages/shared/kbn-slo-schema/src/rest_specs/routes/composite_slo/composite_slo_get.ts
@@ -6,7 +6,11 @@
  */
 import * as t from 'io-ts';
 import { sloIdSchema } from '../../../schema/slo';
-import { compositeSloDefinitionSchema } from '../../../schema/composite_slo';
+import {
+  compositeSloComponentSchema,
+  compositeSloDefinitionSchema,
+  compositeSloSummarySchema,
+} from '../../../schema/composite_slo';
 
 const getCompositeSLOParamsSchema = t.type({
   path: t.type({
@@ -14,7 +18,13 @@ const getCompositeSLOParamsSchema = t.type({
   }),
 });
 
-const getCompositeSLOResponseSchema = compositeSloDefinitionSchema;
+const getCompositeSLOResponseSchema = t.intersection([
+  compositeSloDefinitionSchema,
+  t.type({
+    summary: compositeSloSummarySchema,
+    components: t.array(compositeSloComponentSchema),
+  }),
+]);
 
 type GetCompositeSLOResponse = t.OutputOf<typeof getCompositeSLOResponseSchema>;
 

--- a/x-pack/platform/packages/shared/kbn-slo-schema/src/schema/composite_slo.ts
+++ b/x-pack/platform/packages/shared/kbn-slo-schema/src/schema/composite_slo.ts
@@ -6,7 +6,7 @@
  */
 
 import * as t from 'io-ts';
-import { dateType } from './common';
+import { dateType, errorBudgetSchema, statusSchema } from './common';
 import { rollingTimeWindowSchema } from './time_window';
 import { occurrencesBudgetingMethodSchema, sloIdSchema, tagsSchema, targetSchema } from './slo';
 
@@ -42,12 +42,39 @@ const compositeSloDefinitionSchema = t.type({
 
 const storedCompositeSloDefinitionSchema = compositeSloDefinitionSchema;
 
+const compositeSloComponentSchema = t.intersection([
+  t.type({
+    id: t.string,
+    name: t.string,
+    weight: t.number,
+    normalisedWeight: t.number,
+    sliValue: t.number,
+    contribution: t.number,
+  }),
+  t.partial({
+    instanceId: t.string,
+  }),
+]);
+
+const compositeSloSummarySchema = t.type({
+  sliValue: t.number,
+  errorBudget: errorBudgetSchema,
+  status: statusSchema,
+  fiveMinuteBurnRate: t.number,
+  oneHourBurnRate: t.number,
+  oneDayBurnRate: t.number,
+});
+
 export type CompositeSLOMember = t.TypeOf<typeof compositeSloMemberSchema>;
 export type CompositeMethod = t.TypeOf<typeof compositeMethodSchema>;
+export type CompositeSLOComponent = t.TypeOf<typeof compositeSloComponentSchema>;
+export type CompositeSLOSummary = t.TypeOf<typeof compositeSloSummarySchema>;
 
 export {
   compositeSloMemberSchema,
   compositeMethodSchema,
   compositeSloDefinitionSchema,
   storedCompositeSloDefinitionSchema,
+  compositeSloComponentSchema,
+  compositeSloSummarySchema,
 };

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/composite_slo/get_composite_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/composite_slo/get_composite_slo.ts
@@ -6,7 +6,12 @@
  */
 
 import { getCompositeSLOParamsSchema } from '@kbn/slo-schema';
-import { DefaultCompositeSLORepository } from '../../../services/composite_slo_repository';
+import {
+  DefaultBurnRatesClient,
+  DefaultCompositeSLORepository,
+  DefaultSummaryClient,
+  GetCompositeSLO,
+} from '../../../services';
 import { createSloServerRoute } from '../../create_slo_server_route';
 import { assertPlatinumLicense } from '../utils/assert_platinum_license';
 
@@ -22,9 +27,23 @@ export const getCompositeSLORoute = createSloServerRoute({
   handler: async ({ params, logger, request, plugins, getScopedClients }) => {
     await assertPlatinumLicense(plugins);
 
-    const { soClient } = await getScopedClients({ request, logger });
-    const repository = new DefaultCompositeSLORepository(soClient, logger);
+    const { soClient, scopedClusterClient, repository } = await getScopedClients({
+      request,
+      logger,
+    });
 
-    return await repository.findById(params.path.id);
+    const compositeSloRepository = new DefaultCompositeSLORepository(soClient, logger);
+    const burnRatesClient = new DefaultBurnRatesClient(scopedClusterClient.asCurrentUser);
+    const summaryClient = new DefaultSummaryClient(
+      scopedClusterClient.asCurrentUser,
+      burnRatesClient
+    );
+    const getCompositeSLO = new GetCompositeSLO(
+      compositeSloRepository,
+      repository,
+      summaryClient
+    );
+
+    return await getCompositeSLO.execute(params.path.id);
   },
 });

--- a/x-pack/solutions/observability/plugins/slo/server/services/get_composite_slo.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/get_composite_slo.test.ts
@@ -1,0 +1,322 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createSLO, createAPMTransactionErrorRateIndicator } from './fixtures/slo';
+import { createCompositeSlo } from './fixtures/composite_slo';
+import { GetCompositeSLO } from './get_composite_slo';
+import {
+  createSummaryClientMock,
+  createSLORepositoryMock,
+  createCompositeSLORepositoryMock,
+} from './mocks';
+import type { CompositeSLORepository } from './composite_slo_repository';
+import type { SLODefinitionRepository } from './slo_definition_repository';
+import type { SummaryClient } from './summary_client';
+import type { Summary } from '../domain/models';
+
+const buildSummary = (overrides: Partial<Summary> = {}): Summary => ({
+  status: 'HEALTHY',
+  sliValue: 0.995,
+  errorBudget: { initial: 0.01, consumed: 0.5, remaining: 0.5, isEstimated: false },
+  fiveMinuteBurnRate: 1.2,
+  oneHourBurnRate: 0.9,
+  oneDayBurnRate: 0.8,
+  ...overrides,
+});
+
+describe('GetCompositeSLO', () => {
+  let mockCompositeRepo: jest.Mocked<CompositeSLORepository>;
+  let mockSloRepo: jest.Mocked<SLODefinitionRepository>;
+  let mockSummaryClient: jest.Mocked<SummaryClient>;
+  let getCompositeSLO: GetCompositeSLO;
+
+  beforeEach(() => {
+    mockCompositeRepo = createCompositeSLORepositoryMock();
+    mockSloRepo = createSLORepositoryMock();
+    mockSummaryClient = createSummaryClientMock();
+    getCompositeSLO = new GetCompositeSLO(mockCompositeRepo, mockSloRepo, mockSummaryClient);
+  });
+
+  it('computes weighted SLI from component SLOs', async () => {
+    const sloA = createSLO({
+      id: 'slo-a-xxxxxxxx',
+      name: 'Service A',
+      indicator: createAPMTransactionErrorRateIndicator(),
+    });
+    const sloB = createSLO({
+      id: 'slo-b-xxxxxxxx',
+      name: 'Service B',
+      indicator: createAPMTransactionErrorRateIndicator(),
+    });
+
+    const composite = createCompositeSlo({
+      members: [
+        { sloId: sloA.id, weight: 6 },
+        { sloId: sloB.id, weight: 4 },
+      ],
+      objective: { target: 0.99 },
+    });
+
+    mockCompositeRepo.findById.mockResolvedValue(composite);
+    mockSloRepo.findAllByIds.mockResolvedValue([sloA, sloB]);
+
+    mockSummaryClient.computeSummary
+      .mockResolvedValueOnce({
+        groupings: {},
+        meta: {},
+        summary: buildSummary({
+          sliValue: 0.995,
+          fiveMinuteBurnRate: 1.0,
+          oneHourBurnRate: 0.8,
+          oneDayBurnRate: 0.5,
+        }),
+      })
+      .mockResolvedValueOnce({
+        groupings: {},
+        meta: {},
+        summary: buildSummary({
+          sliValue: 0.98,
+          fiveMinuteBurnRate: 2.0,
+          oneHourBurnRate: 1.5,
+          oneDayBurnRate: 1.0,
+        }),
+      });
+
+    const result = await getCompositeSLO.execute(composite.id);
+
+    // normalisedWeight: sloA = 6/10 = 0.6, sloB = 4/10 = 0.4
+    // compositeSLI = 0.6 * 0.995 + 0.4 * 0.98 = 0.597 + 0.392 = 0.989
+    expect(result.summary.sliValue).toBeCloseTo(0.989, 3);
+    expect(result.summary.status).toBe('DEGRADING');
+
+    // composite 5m burn rate = 0.6 * 1.0 + 0.4 * 2.0 = 1.4
+    expect(result.summary.fiveMinuteBurnRate).toBeCloseTo(1.4, 3);
+    // composite 1h burn rate = 0.6 * 0.8 + 0.4 * 1.5 = 1.08
+    expect(result.summary.oneHourBurnRate).toBeCloseTo(1.08, 3);
+    // composite 1d burn rate = 0.6 * 0.5 + 0.4 * 1.0 = 0.7
+    expect(result.summary.oneDayBurnRate).toBeCloseTo(0.7, 3);
+
+    expect(result.components).toHaveLength(2);
+    expect(result.components[0]).toMatchObject({
+      id: sloA.id,
+      name: 'Service A',
+      weight: 6,
+      normalisedWeight: 0.6,
+    });
+    expect(result.components[1]).toMatchObject({
+      id: sloB.id,
+      name: 'Service B',
+      weight: 4,
+      normalisedWeight: 0.4,
+    });
+  });
+
+  it('computes error budget from composite SLI and target', async () => {
+    const sloA = createSLO({
+      id: 'slo-a-xxxxxxxx',
+      name: 'A',
+      indicator: createAPMTransactionErrorRateIndicator(),
+    });
+
+    const composite = createCompositeSlo({
+      members: [{ sloId: sloA.id, weight: 1 }],
+      objective: { target: 0.99 },
+    });
+
+    mockCompositeRepo.findById.mockResolvedValue(composite);
+    mockSloRepo.findAllByIds.mockResolvedValue([sloA]);
+    mockSummaryClient.computeSummary.mockResolvedValueOnce({
+      groupings: {},
+      meta: {},
+      summary: buildSummary({ sliValue: 0.995 }),
+    });
+
+    const result = await getCompositeSLO.execute(composite.id);
+
+    // initialErrorBudget = 1 - 0.99 = 0.01
+    // consumed = (1 - 0.995) / 0.01 = 0.5
+    // remaining = 1 - 0.5 = 0.5
+    expect(result.summary.errorBudget.initial).toBeCloseTo(0.01, 4);
+    expect(result.summary.errorBudget.consumed).toBeCloseTo(0.5, 4);
+    expect(result.summary.errorBudget.remaining).toBeCloseTo(0.5, 4);
+  });
+
+  it('excludes members with no data and re-normalises weights', async () => {
+    const sloA = createSLO({
+      id: 'slo-a-xxxxxxxx',
+      name: 'With Data',
+      indicator: createAPMTransactionErrorRateIndicator(),
+    });
+    const sloB = createSLO({
+      id: 'slo-b-xxxxxxxx',
+      name: 'No Data',
+      indicator: createAPMTransactionErrorRateIndicator(),
+    });
+
+    const composite = createCompositeSlo({
+      members: [
+        { sloId: sloA.id, weight: 3 },
+        { sloId: sloB.id, weight: 7 },
+      ],
+      objective: { target: 0.99 },
+    });
+
+    mockCompositeRepo.findById.mockResolvedValue(composite);
+    mockSloRepo.findAllByIds.mockResolvedValue([sloA, sloB]);
+
+    mockSummaryClient.computeSummary
+      .mockResolvedValueOnce({
+        groupings: {},
+        meta: {},
+        summary: buildSummary({ sliValue: 0.995 }),
+      })
+      .mockResolvedValueOnce({
+        groupings: {},
+        meta: {},
+        summary: buildSummary({ sliValue: -1 }),
+      });
+
+    const result = await getCompositeSLO.execute(composite.id);
+
+    // sloB has no data (-1), so only sloA participates with normalisedWeight = 1.0
+    expect(result.summary.sliValue).toBeCloseTo(0.995, 4);
+    expect(result.components[0].normalisedWeight).toBe(1);
+    expect(result.components[1].normalisedWeight).toBe(0);
+    expect(result.components[1].sliValue).toBe(-1);
+    expect(result.components[1].contribution).toBe(0);
+  });
+
+  it('returns NO_DATA status when all components lack data', async () => {
+    const sloA = createSLO({
+      id: 'slo-a-xxxxxxxx',
+      name: 'No Data A',
+      indicator: createAPMTransactionErrorRateIndicator(),
+    });
+    const sloB = createSLO({
+      id: 'slo-b-xxxxxxxx',
+      name: 'No Data B',
+      indicator: createAPMTransactionErrorRateIndicator(),
+    });
+
+    const composite = createCompositeSlo({
+      members: [
+        { sloId: sloA.id, weight: 1 },
+        { sloId: sloB.id, weight: 1 },
+      ],
+    });
+
+    mockCompositeRepo.findById.mockResolvedValue(composite);
+    mockSloRepo.findAllByIds.mockResolvedValue([sloA, sloB]);
+
+    mockSummaryClient.computeSummary
+      .mockResolvedValueOnce({
+        groupings: {},
+        meta: {},
+        summary: buildSummary({ sliValue: -1 }),
+      })
+      .mockResolvedValueOnce({
+        groupings: {},
+        meta: {},
+        summary: buildSummary({ sliValue: -1 }),
+      });
+
+    const result = await getCompositeSLO.execute(composite.id);
+
+    expect(result.summary.sliValue).toBe(-1);
+    expect(result.summary.status).toBe('NO_DATA');
+  });
+
+  it('skips deleted members that no longer exist in the repository', async () => {
+    const sloA = createSLO({
+      id: 'slo-a-xxxxxxxx',
+      name: 'Existing',
+      indicator: createAPMTransactionErrorRateIndicator(),
+    });
+
+    const composite = createCompositeSlo({
+      members: [
+        { sloId: sloA.id, weight: 1 },
+        { sloId: 'deleted-xxxxxxxx', weight: 2 },
+      ],
+      objective: { target: 0.99 },
+    });
+
+    mockCompositeRepo.findById.mockResolvedValue(composite);
+    // findAllByIds only returns sloA; deleted SLO is not returned
+    mockSloRepo.findAllByIds.mockResolvedValue([sloA]);
+
+    mockSummaryClient.computeSummary.mockResolvedValueOnce({
+      groupings: {},
+      meta: {},
+      summary: buildSummary({ sliValue: 0.995 }),
+    });
+
+    const result = await getCompositeSLO.execute(composite.id);
+
+    // Only sloA participates
+    expect(result.summary.sliValue).toBeCloseTo(0.995, 4);
+    expect(result.components).toHaveLength(1);
+    expect(result.components[0].id).toBe(sloA.id);
+    expect(result.components[0].normalisedWeight).toBe(1);
+  });
+
+  it('passes instanceId to summary client when member specifies it', async () => {
+    const sloA = createSLO({
+      id: 'slo-a-xxxxxxxx',
+      name: 'A',
+      indicator: createAPMTransactionErrorRateIndicator(),
+    });
+
+    const composite = createCompositeSlo({
+      members: [{ sloId: sloA.id, weight: 1, instanceId: 'my-instance' }],
+    });
+
+    mockCompositeRepo.findById.mockResolvedValue(composite);
+    mockSloRepo.findAllByIds.mockResolvedValue([sloA]);
+    mockSummaryClient.computeSummary.mockResolvedValueOnce({
+      groupings: {},
+      meta: {},
+      summary: buildSummary({ sliValue: 0.999 }),
+    });
+
+    const result = await getCompositeSLO.execute(composite.id);
+
+    expect(mockSummaryClient.computeSummary).toHaveBeenCalledWith({
+      slo: sloA,
+      instanceId: 'my-instance',
+    });
+    expect(result.components[0].instanceId).toBe('my-instance');
+  });
+
+  it('returns VIOLATED status when composite SLI is below target and error budget exhausted', async () => {
+    const sloA = createSLO({
+      id: 'slo-a-xxxxxxxx',
+      name: 'Violated',
+      indicator: createAPMTransactionErrorRateIndicator(),
+    });
+
+    const composite = createCompositeSlo({
+      members: [{ sloId: sloA.id, weight: 1 }],
+      objective: { target: 0.999 },
+    });
+
+    mockCompositeRepo.findById.mockResolvedValue(composite);
+    mockSloRepo.findAllByIds.mockResolvedValue([sloA]);
+    mockSummaryClient.computeSummary.mockResolvedValueOnce({
+      groupings: {},
+      meta: {},
+      summary: buildSummary({ sliValue: 0.95 }),
+    });
+
+    const result = await getCompositeSLO.execute(composite.id);
+
+    // initialErrorBudget = 0.001, consumed = (1 - 0.95) / 0.001 = 50
+    // remaining = 1 - 50 = -49 < 0
+    expect(result.summary.status).toBe('VIOLATED');
+    expect(result.summary.errorBudget.remaining).toBeLessThan(0);
+  });
+});

--- a/x-pack/solutions/observability/plugins/slo/server/services/get_composite_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/get_composite_slo.ts
@@ -1,0 +1,159 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  CompositeSLOComponent,
+  CompositeSLOSummary,
+  GetCompositeSLOResponse,
+} from '@kbn/slo-schema';
+import { ALL_VALUE, getCompositeSLOResponseSchema } from '@kbn/slo-schema';
+import { toHighPrecision } from '../utils/number';
+import type { CompositeSLODefinition } from '../domain/models';
+import { computeSummaryStatus, toErrorBudget } from '../domain/services';
+import type { CompositeSLORepository } from './composite_slo_repository';
+import type { SLODefinitionRepository } from './slo_definition_repository';
+import type { SummaryClient } from './summary_client';
+
+const NO_DATA = -1;
+
+export class GetCompositeSLO {
+  constructor(
+    private compositeSloRepository: CompositeSLORepository,
+    private sloDefinitionRepository: SLODefinitionRepository,
+    private summaryClient: SummaryClient
+  ) {}
+
+  public async execute(id: string): Promise<GetCompositeSLOResponse> {
+    const compositeSlo = await this.compositeSloRepository.findById(id);
+    const memberSloIds = compositeSlo.members.map((m) => m.sloId);
+    const memberDefinitions = await this.sloDefinitionRepository.findAllByIds(memberSloIds);
+
+    const memberDefinitionMap = new Map(memberDefinitions.map((slo) => [slo.id, slo]));
+
+    const memberSummaries = await Promise.all(
+      compositeSlo.members
+        .filter((member) => memberDefinitionMap.has(member.sloId))
+        .map(async (member) => {
+          const slo = memberDefinitionMap.get(member.sloId)!;
+          const instanceId = member.instanceId ?? ALL_VALUE;
+          const { summary } = await this.summaryClient.computeSummary({ slo, instanceId });
+
+          return {
+            member,
+            sloName: slo.name,
+            summary,
+          };
+        })
+    );
+
+    const { compositeSummary, components } = this.computeWeightedAggregate(
+      compositeSlo,
+      memberSummaries
+    );
+
+    return getCompositeSLOResponseSchema.encode({
+      ...compositeSlo,
+      summary: compositeSummary,
+      components,
+    });
+  }
+
+  private computeWeightedAggregate(
+    compositeSlo: CompositeSLODefinition,
+    memberSummaries: Array<{
+      member: { sloId: string; weight: number; instanceId?: string };
+      sloName: string;
+      summary: { sliValue: number; fiveMinuteBurnRate: number; oneHourBurnRate: number; oneDayBurnRate: number };
+    }>
+  ): { compositeSummary: CompositeSLOSummary; components: CompositeSLOComponent[] } {
+    const activeMembers = memberSummaries.filter((ms) => ms.summary.sliValue !== NO_DATA);
+
+    if (activeMembers.length === 0) {
+      return {
+        compositeSummary: this.buildNoDataSummary(),
+        components: memberSummaries.map((ms) => this.buildComponent(ms, 0)),
+      };
+    }
+
+    const totalWeight = activeMembers.reduce((sum, ms) => sum + ms.member.weight, 0);
+
+    let compositeSliValue = 0;
+    let compositeFiveMinBurnRate = 0;
+    let compositeOneHourBurnRate = 0;
+    let compositeOneDayBurnRate = 0;
+
+    const components: CompositeSLOComponent[] = memberSummaries.map((ms) => {
+      const isActive = ms.summary.sliValue !== NO_DATA;
+      const normalisedWeight = isActive ? toHighPrecision(ms.member.weight / totalWeight) : 0;
+
+      if (isActive) {
+        compositeSliValue += normalisedWeight * ms.summary.sliValue;
+        compositeFiveMinBurnRate += normalisedWeight * ms.summary.fiveMinuteBurnRate;
+        compositeOneHourBurnRate += normalisedWeight * ms.summary.oneHourBurnRate;
+        compositeOneDayBurnRate += normalisedWeight * ms.summary.oneDayBurnRate;
+      }
+
+      return this.buildComponent(ms, normalisedWeight);
+    });
+
+    compositeSliValue = toHighPrecision(compositeSliValue);
+    compositeFiveMinBurnRate = toHighPrecision(compositeFiveMinBurnRate);
+    compositeOneHourBurnRate = toHighPrecision(compositeOneHourBurnRate);
+    compositeOneDayBurnRate = toHighPrecision(compositeOneDayBurnRate);
+
+    const { target } = compositeSlo.objective;
+    const initialErrorBudget = 1 - target;
+    const consumedErrorBudget =
+      compositeSliValue < 0 ? 0 : (1 - compositeSliValue) / initialErrorBudget;
+    const errorBudget = toErrorBudget(initialErrorBudget, consumedErrorBudget);
+
+    return {
+      compositeSummary: {
+        sliValue: compositeSliValue,
+        errorBudget,
+        status: computeSummaryStatus(compositeSlo.objective, compositeSliValue, errorBudget),
+        fiveMinuteBurnRate: compositeFiveMinBurnRate,
+        oneHourBurnRate: compositeOneHourBurnRate,
+        oneDayBurnRate: compositeOneDayBurnRate,
+      },
+      components,
+    };
+  }
+
+  private buildComponent(
+    ms: {
+      member: { sloId: string; weight: number; instanceId?: string };
+      sloName: string;
+      summary: { sliValue: number };
+    },
+    normalisedWeight: number
+  ): CompositeSLOComponent {
+    const sliValue = ms.summary.sliValue;
+    const contribution = sliValue === NO_DATA ? 0 : toHighPrecision(normalisedWeight * sliValue);
+
+    return {
+      id: ms.member.sloId,
+      name: ms.sloName,
+      weight: ms.member.weight,
+      normalisedWeight,
+      sliValue,
+      contribution,
+      ...(ms.member.instanceId !== undefined ? { instanceId: ms.member.instanceId } : {}),
+    };
+  }
+
+  private buildNoDataSummary(): CompositeSLOSummary {
+    return {
+      sliValue: NO_DATA,
+      errorBudget: toErrorBudget(0, 0),
+      status: 'NO_DATA',
+      fiveMinuteBurnRate: 0,
+      oneHourBurnRate: 0,
+      oneDayBurnRate: 0,
+    };
+  }
+}

--- a/x-pack/solutions/observability/plugins/slo/server/services/index.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/index.ts
@@ -26,3 +26,4 @@ export * from './summary_search_client/summary_search_client';
 export * from './search_slo_definitions';
 export * from './slo_definition_client';
 export * from './composite_slo_repository';
+export * from './get_composite_slo';

--- a/x-pack/solutions/observability/plugins/slo/server/services/mocks/index.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/mocks/index.ts
@@ -7,6 +7,7 @@
 
 import type { ResourceInstaller } from '../resource_installer';
 import type { BurnRatesClient } from '../burn_rates_client';
+import type { CompositeSLORepository } from '../composite_slo_repository';
 import type { SLODefinitionRepository } from '../slo_definition_repository';
 import type { SummaryClient } from '../summary_client';
 import type { SummarySearchClient } from '../summary_search_client/types';
@@ -71,6 +72,16 @@ const createBurnRatesClientMock = (): jest.Mocked<BurnRatesClient> => {
   };
 };
 
+const createCompositeSLORepositoryMock = (): jest.Mocked<CompositeSLORepository> => {
+  return {
+    create: jest.fn(),
+    update: jest.fn(),
+    findById: jest.fn(),
+    deleteById: jest.fn(),
+    search: jest.fn(),
+  };
+};
+
 export {
   createResourceInstallerMock,
   createTransformManagerMock,
@@ -79,4 +90,5 @@ export {
   createSummaryClientMock,
   createSummarySearchClientMock,
   createBurnRatesClientMock,
+  createCompositeSLORepositoryMock,
 };


### PR DESCRIPTION
## Summary

Implements the Phase 1 on-the-fly computation engine for composite SLOs as described in elastic/kibana#259101.

When the `GET /api/observability/slo_composites/{id}` API is called, the composite SLO's aggregated values are now computed on the fly from the underlying component SLOs instead of returning only the stored definition.

### Key changes:

- **Schema (`@kbn/slo-schema`)**: Added `compositeSloSummarySchema` and `compositeSloComponentSchema` io-ts types. Updated the GET response to include `summary` and `components` alongside the definition.
- **`GetCompositeSLO` service**: New service that orchestrates the computation — loads the composite definition, fetches member SLO definitions, computes individual summaries in parallel, then applies weighted mean aggregation.
- **Computation logic**:
  - **Weighted SLI**: `compositeSLI = Σ(normalisedWeight_i × SLI_i)` where weights are normalised to sum to 100%
  - **Error budget**: Derived from composite SLI and composite target
  - **Burn rates**: Weighted mean of component burn rates (5m, 1h, 1d windows)
  - **Edge cases**: Components with no data are excluded and weights re-normalised; all-no-data returns `NO_DATA` status; deleted/missing members are silently skipped
- **Route update**: `GET /api/observability/slo_composites/{id}` now wires the `SummaryClient` and `BurnRatesClient` to compute live values.
- **Tests**: Comprehensive unit tests covering weighted aggregation, error budget, no-data handling, deleted members, instanceId passthrough, and violated status.

### API response shape (illustrative)

```json
{
  "id": "composite-slo-id",
  "name": "Checkout Journey",
  "summary": {
    "sliValue": 0.986,
    "errorBudget": { "initial": 0.01, "consumed": 0.28, "remaining": 0.72, "isEstimated": false },
    "status": "HEALTHY",
    "fiveMinuteBurnRate": 1.2,
    "oneHourBurnRate": 0.9,
    "oneDayBurnRate": 0.8
  },
  "components": [
    {
      "id": "component-a-id",
      "name": "Payment Service",
      "weight": 6,
      "normalisedWeight": 0.60,
      "sliValue": 0.995,
      "contribution": 0.597
    }
  ]
}
```

## Test plan

- [ ] Unit tests pass for `GetCompositeSLO` service
- [ ] Type checks pass
- [ ] Verify GET composite SLO API returns computed summary with real component SLOs
- [ ] Verify edge case: component with no data is excluded, remaining weights re-normalised
- [ ] Verify edge case: all components no data returns NO_DATA status
- [ ] Verify edge case: deleted member SLO is silently skipped


Made with [Cursor](https://cursor.com)